### PR TITLE
Add and configure eslint-config-turbo in packages/eslint-config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7431,6 +7431,20 @@
         "eslint": ">=7.0.0"
       }
     },
+    "node_modules/eslint-config-turbo": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-turbo/-/eslint-config-turbo-2.5.8.tgz",
+      "integrity": "sha512-wzxmN7dJNFGDwOvR/4j8U2iaIH/ruYez8qg/sCKrezJ3+ljbFMvJLmgKKt/1mDuyU9wj5aZqO6VijP3QH169FA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-plugin-turbo": "2.5.8"
+      },
+      "peerDependencies": {
+        "eslint": ">6.6.0",
+        "turbo": ">2.0.0"
+      }
+    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
@@ -7799,6 +7813,30 @@
       "peerDependencies": {
         "eslint": ">=8",
         "storybook": "^9.1.3"
+      }
+    },
+    "node_modules/eslint-plugin-turbo": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-turbo/-/eslint-plugin-turbo-2.5.8.tgz",
+      "integrity": "sha512-bVjx4vTH0oTKIyQ7EGFAXnuhZMrKIfu17qlex/dps7eScPnGQLJ3r1/nFq80l8xA+8oYjsSirSQ2tXOKbz3kEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "16.0.3"
+      },
+      "peerDependencies": {
+        "eslint": ">6.6.0",
+        "turbo": ">2.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-turbo/node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/eslint-scope": {
@@ -14478,6 +14516,9 @@
     "packages/eslint-config": {
       "name": "@curso-em-texto/eslint-config",
       "version": "0.0.1",
+      "devDependencies": {
+        "eslint-config-turbo": "^2.5.8"
+      },
       "peerDependencies": {
         "@eslint/js": "^9.33.0",
         "@typescript-eslint/eslint-plugin": "^8.40.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7435,8 +7435,8 @@
       "version": "2.5.8",
       "resolved": "https://registry.npmjs.org/eslint-config-turbo/-/eslint-config-turbo-2.5.8.tgz",
       "integrity": "sha512-wzxmN7dJNFGDwOvR/4j8U2iaIH/ruYez8qg/sCKrezJ3+ljbFMvJLmgKKt/1mDuyU9wj5aZqO6VijP3QH169FA==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eslint-plugin-turbo": "2.5.8"
       },
@@ -7819,8 +7819,8 @@
       "version": "2.5.8",
       "resolved": "https://registry.npmjs.org/eslint-plugin-turbo/-/eslint-plugin-turbo-2.5.8.tgz",
       "integrity": "sha512-bVjx4vTH0oTKIyQ7EGFAXnuhZMrKIfu17qlex/dps7eScPnGQLJ3r1/nFq80l8xA+8oYjsSirSQ2tXOKbz3kEw==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dotenv": "16.0.3"
       },
@@ -7833,8 +7833,8 @@
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
       "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -13565,7 +13565,6 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.5.6.tgz",
       "integrity": "sha512-gxToHmi9oTBNB05UjUsrWf0OyN5ZXtD0apOarC1KIx232Vp3WimRNy3810QzeNSgyD5rsaIDXlxlbnOzlouo+w==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "turbo": "bin/turbo"
@@ -13586,7 +13585,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13600,7 +13598,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13614,7 +13611,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13628,7 +13624,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13642,7 +13637,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13656,7 +13650,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14516,15 +14509,13 @@
     "packages/eslint-config": {
       "name": "@curso-em-texto/eslint-config",
       "version": "0.0.1",
-      "devDependencies": {
-        "eslint-config-turbo": "^2.5.8"
-      },
       "peerDependencies": {
         "@eslint/js": "^9.33.0",
         "@typescript-eslint/eslint-plugin": "^8.40.0",
         "@typescript-eslint/parser": "^8.40.0",
         "eslint": "^9.33.0",
         "eslint-config-prettier": "^10.1.8",
+        "eslint-config-turbo": "^2.5.8",
         "eslint-plugin-prettier": "^5.5.4"
       }
     },

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -42,7 +42,7 @@ export default [
       'turbo/no-undeclared-env-vars': [
         'error',
         {
-          allowList: ['NODE_ENV']
+          allowList: ['NODE_ENV', 'NEXT_PUBLIC_*']
         },
       ],
     },

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -3,9 +3,11 @@ import ts from '@typescript-eslint/eslint-plugin';
 import tsParser from '@typescript-eslint/parser';
 import prettier from 'eslint-plugin-prettier';
 import prettierConfig from 'eslint-config-prettier';
+import turboConfig from 'eslint-config-turbo/flat';
 
 /** @type {import("eslint").Linter.Config} */
 export default [
+  ...turboConfig,
   {
     ignores: ['node_modules', 'dist', '.next', 'coverage'],
   },
@@ -37,6 +39,12 @@ export default [
         { argsIgnorePattern: '^_' },
       ],
       '@typescript-eslint/no-non-null-assertion': 'warn',
+      'turbo/no-undeclared-env-vars': [
+        'error',
+        {
+          allowList: ['NODE_ENV']
+        },
+      ],
     },
   },
 ];

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -10,9 +10,7 @@
     "@typescript-eslint/parser": "^8.40.0",
     "eslint": "^9.33.0",
     "eslint-config-prettier": "^10.1.8",
-    "eslint-plugin-prettier": "^5.5.4"
-  },
-  "devDependencies": {
+    "eslint-plugin-prettier": "^5.5.4",
     "eslint-config-turbo": "^2.5.8"
   }
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -11,5 +11,8 @@
     "eslint": "^9.33.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4"
+  },
+  "devDependencies": {
+    "eslint-config-turbo": "^2.5.8"
   }
 }


### PR DESCRIPTION
This PR adds the `eslint-config-turbo` package to the `@curso-em-texto/eslint-config` package and configures it in the ESLint flat config.

Changes include:
- Installing `eslint-config-turbo` as a dev dependency.
- Updating `packages/eslint-config/index.js` to extend `eslint-config-turbo/flat`.
- Configuring the rule `turbo/no-undeclared-env-vars` with an allowList for environment variables.

✅ Lint has been run and verified with no errors.

---

**Disclaimer for Hacktoberfest:**
Please add the `hackertoberfest-accepted` label to this PR if everything looks good, as I am participating in Hacktoberfest 2025.

#29 